### PR TITLE
Fix for newest Rakudo

### DIFF
--- a/lib/Digest/MD5.pm
+++ b/lib/Digest/MD5.pm
@@ -6,7 +6,7 @@ class Digest::MD5:auth<cosimo>:ver<0.04> {
 
     # Use .pir, not .pbc!
     # See https://trac.parrot.org/parrot/ticket/1694
-    pir::load_bytecode('Digest/MD5.pir');
+    pir::load_bytecode__vs('Digest/MD5.pir');
 
     multi method md5_hex (Str $str) {
 


### PR DESCRIPTION
it now requires explicit signatures on all pir:: opcodes (most are replaced
with nqp:: variants by now)
