### PR TITLE
'our' scope `md5()` function - make it externally accessible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ as a hex string.
 Takes same arguments as `md5_hex`, except returns a
 [Buf](http://docs.perl6.org/type/Buf) instead of a string.
 
+### Subroutines
+
+### `Digest::MD5::md5`
+```perl6
+my $data = $str.encode('ascii');
+my $md5_buf = Digest::MD5::md5($data);
+
+    # returns Buf:0x<8d 77 7f 38 5d 3d fe c8 81 5d 20 f7 49 60 26 dc>
+```
+
+Takes a buffer or array as an argument. Returns a [Buf](http://docs.perl6.org/type/Buf).
+
 ### Repository
 
   http://github.com/cosimo/perl6-digest-md5

--- a/lib/Digest/MD5.pm
+++ b/lib/Digest/MD5.pm
@@ -48,7 +48,7 @@ class Digest::MD5:auth<cosimo>:ver<0.05> {
         @H «⊞=» ($A, $B, $C, $D);
     }
 
-    sub md5($msg) {
+    our sub md5($msg) {
         my @M = md5-pad($msg);
         my @H = 0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476;
         md5-block(@H, @M[$_ .. $_+15]) for 0, 16 ...^ +@M;

--- a/t/1-readme.t
+++ b/t/1-readme.t
@@ -1,0 +1,19 @@
+use v6;
+use Digest::MD5;
+use Test;
+
+plan 3;
+my $d = Digest::MD5.new;
+my $expected-buf = Buf.new: 0x8d, 0x77, 0x7f, 0x38, 0x5d, 0x3d, 0xfe, 0xc8, 0x81, 0x5d, 0x20, 0xf7, 0x49, 0x60, 0x26, 0xdc;
+my $expected-hash = '009ef1defa9fa27032f9f52cdeda8698';
+
+my $md5_buf = $d.md5_buf('data');
+is-deeply $md5_buf, $expected-buf, 'md5_buf sanity';
+
+my @data = "one", "two", "and more";
+my $md5_hash = $d.md5_hex( @data );
+is $md5_hash, $expected-hash, 'md5_hex sanity';
+
+my $data = 'data'.encode('ascii');
+$md5_buf = Digest::MD5::md5($data);
+is-deeply $md5_buf, $expected-buf, 'Digest::MD5::md5 sanity';


### PR DESCRIPTION
This is to support work in progress in a new module that I'm constructing https://github.com/p6-pdf/perl6-PDF-Tools. Work in progress on encryption in `crypt` branch.

I'm calling the subroutine repeatedly from a Buf to a Buf and don't want or need the marshaling performed by the `md5_buf` or `med5_hex` methods.