### PR TITLE
Updated to conform to new newline handling

### DIFF
--- a/t/perl5-compat.t
+++ b/t/perl5-compat.t
@@ -4,6 +4,7 @@
 
 use Test;
 use Digest::MD5;
+use newline :lf;
 
 plan 24;
 


### PR DESCRIPTION
This stops the test from breaking on windows due to automatic conversion of "\n" to "\r\n"